### PR TITLE
Fix typo "spicy now changes" in 4.19 blog post

### DIFF
--- a/site/blog/4-11-2025_4_19_release.php
+++ b/site/blog/4-11-2025_4_19_release.php
@@ -62,7 +62,7 @@ you can check out the `wii-v5.4` branch on the kernel repo on GitHub, to see
 what I did, but it doesn't really work.  It compiles, it technically boots,
 but USB is completely broken, and the SD Card is incredibly unstable.
 
-However, I will continue to iterate on 4.19, with some spicy now changes
+However, I will continue to iterate on 4.19, with some spicy new changes
 planned.  In no particular order:
 * GameCube support
 * Fixing rvl-di (Wii DVD drive)


### PR DESCRIPTION
Typo fix: "spicy now changes" -> "spicy new changes"